### PR TITLE
AlternativeNames support.

### DIFF
--- a/app/src/main/java/com/github/shadowsocks/plugin/ck_client/ConfigFragment.kt
+++ b/app/src/main/java/com/github/shadowsocks/plugin/ck_client/ConfigFragment.kt
@@ -16,8 +16,8 @@ class ConfigFragment : PreferenceFragmentCompat() {
         this.options = options
         val ary = arrayOf(Pair("ProxyMethod","shadowsocks"), Pair("EncryptionMethod","plain"),
                 Pair("Transport", "direct"), Pair("UID", ""), Pair("PublicKey",""), Pair("ServerName", "bing.com"),
-                Pair("CDNOriginHost", ""), Pair("NumConn","4"), Pair("BrowserSig", "chrome"),
-                Pair("StreamTimeout","300"), Pair("KeepAlive", "0"))
+                Pair("AlternativeNames", ""), Pair("CDNOriginHost", ""), Pair("NumConn","4"),
+                Pair("BrowserSig", "chrome"), Pair("StreamTimeout","300"), Pair("KeepAlive", "0"))
         for (element in ary) {
             val key = element.first
             val defaultValue = element.second

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <string name="app_name">Cloak</string>
     <string name="cloak_server_name">Server Name</string>
+    <string name="cloak_alternative_names">Alternative Names (comma separated)</string>
     <string name="cloak_cdn_origin_host">CDN mode HTTP Origin Override</string>
     <string name="cloak_uid">UID</string>
     <string name="cloak_public_key">Public Key</string>

--- a/app/src/main/res/xml/config.xml
+++ b/app/src/main/res/xml/config.xml
@@ -26,6 +26,10 @@
             android:persistent="false"
             android:title="@string/cloak_server_name" />
         <EditTextPreference
+            android:key="AlternativeNames"
+            android:persistent="false"
+            android:title="@string/cloak_alternative_names" />
+        <EditTextPreference
             android:key="CDNOriginHost"
             android:persistent="false"
             android:title="@string/cloak_cdn_origin_host" />


### PR DESCRIPTION
This should add AlternativeNames support to the android client, to be input comma separated.